### PR TITLE
chore: generate ts declarations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ TARGETS = $(HDR_TARGETS) \
 	$(JSON_TARGETS) $(WOFF_TARGETS) \
 	$(GLB_TARGETS) $(GLTF_TARGETS)
 
-all: $(TARGETS)
+all: $(TARGETS) ts-declarations
 
 $(DIST)/%.js: $(SRC)/%.b64
 	mkdir -p $(dir $@)
@@ -79,3 +79,7 @@ $(DIST)/%.js: $(SRC)/%.b64
 .PHONY: clean
 clean:
 	rm -rf $(DIST)
+
+.PHONY: ts-declarations
+ts-declarations:
+	cd $(DIST) && npx -p typescript tsc **/*.js --declaration --allowJs --emitDeclarationOnly

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@gltf-transform/cli": "^3.4.0",
     "copyfiles": "^2.3.0",
     "json": "^11.0.0",
-    "semantic-release": "^20.1.1"
+    "semantic-release": "^20.1.1",
+    "typescript": "^5.6.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds a post-build step to the Makefile to generate typescript declaration files.

Closes: #8 