### PR TITLE
chore: generate ts declaration files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ TARGETS = $(HDR_TARGETS) \
 	$(JSON_TARGETS) $(WOFF_TARGETS) \
 	$(GLB_TARGETS) $(GLTF_TARGETS)
 
-all: $(TARGETS)
+all: $(TARGETS) ts-declarations
 
 $(DIST)/%.js: $(SRC)/%.b64
 	mkdir -p $(dir $@)
@@ -79,3 +79,7 @@ $(DIST)/%.js: $(SRC)/%.b64
 .PHONY: clean
 clean:
 	rm -rf $(DIST)
+
+.PHONY: ts-declarations
+ts-declarations:
+	cd $(DIST) && npx -p typescript tsc **/*.js --declaration --allowJs --emitDeclarationOnly --skipLibCheck

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ TARGETS = $(HDR_TARGETS) \
 	$(JSON_TARGETS) $(WOFF_TARGETS) \
 	$(GLB_TARGETS) $(GLTF_TARGETS)
 
-all: $(TARGETS) ts-declarations
+all: $(TARGETS)
 
 $(DIST)/%.js: $(SRC)/%.b64
 	mkdir -p $(dir $@)
@@ -79,7 +79,3 @@ $(DIST)/%.js: $(SRC)/%.b64
 .PHONY: clean
 clean:
 	rm -rf $(DIST)
-
-.PHONY: ts-declarations
-ts-declarations:
-	cd $(DIST) && npx -p typescript tsc **/*.js --declaration --allowJs --emitDeclarationOnly --skipLibCheck

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rm -rf dist && make && npm run copy",
+    "build": "rm -rf dist && make && npm run ts-declarations && npm run copy",
+    "ts-declarations": "tsc dist/**/*.js --declaration --allowJs --emitDeclarationOnly --outDir dist --skipLibCheck",
     "copy": "copyfiles package.json README.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\"",
     "release": "semantic-release"
   },
@@ -31,5 +32,6 @@
   "bugs": {
     "url": "https://github.com/pmndrs/assets/issues"
   },
-  "homepage": "https://github.com/pmndrs/assets#readme"
+  "homepage": "https://github.com/pmndrs/assets#readme",
+  "packageManager": "yarn@1.22.22"
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@gltf-transform/cli": "^3.4.0",
     "copyfiles": "^2.3.0",
     "json": "^11.0.0",
-    "semantic-release": "^20.1.1"
+    "semantic-release": "^20.1.1",
+    "typescript": "^5.6.2"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4836,6 +4836,11 @@ type-fest@^3.0.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.11.1.tgz#d8e62c7f42e14537d5b8796de5450d541f3a33a7"
   integrity sha512-aCuRNRERRVh33lgQaJRlUxZqzfhzwTrsE98Mc3o3VXqmiaQdHacgUtJ0esp+7MvZ92qhtzKPeusaX6vIEcoreA==
 
+typescript@^5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
+  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
+
 uglify-js@^3.1.4:
   version "3.17.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"


### PR DESCRIPTION
EDIT: Now follows #9 but with the `--skipLibCheck` flag


~~We discussed `typeVersions` in #8 and `tsc --emitDeclaration` in #9.~~

~~The tsc method introduces another dependency (which would break in CI). It also outputs the entire base64-encoded string as the type, for example:~~

```typescript
declare const _default = 'data:application/json;base64,eyJnbH....'
export default _default
```

~~I’m unsure if this could cause performance issues with the tsserver, but it seems somewhat redundant.~~

~~This PR ensures that each file gets a corresponding declaration file with the following content:~~

```typescript
declare const _default = 'base64'
export default _default
```

~~Result:~~
![image](https://github.com/user-attachments/assets/2de028c2-2975-460a-90dd-1dbb5a25ab39)
